### PR TITLE
Fix compilation on Ubuntu 22.04.2 LTS

### DIFF
--- a/src/display/disp_ssd.h
+++ b/src/display/disp_ssd.h
@@ -9,6 +9,6 @@
 
 void disp_ssd_init(void);
 
-void (*disp_write)(uint8_t x, uint8_t y, char *message);
+extern void (*disp_write)(uint8_t x, uint8_t y, char *message);
 
 #endif // _DISPLAY_DISP_SSD_H


### PR DESCRIPTION
Compiler: (Ubuntu 22.04.2 LTS)
 gcc version 10.3.1 20210621 (release) (15:10.3-2021.07-4)

Error:
 [100%] Linking CXX executable amigahid-pico.elf
 .../ld: CMakeFiles/amigahid-pico.dir/util/debug_cons.c.obj:(.bss.disp_write+0x0):
	multiple definition of `disp_write';
	CMakeFiles/amigahid-pico.dir/main.c.obj:(.bss.disp_write+0x0): first defined here
 .../ld: CMakeFiles/amigahid-pico.dir/display/disp_ssd.c.obj:(.data.disp_write+0x0):
	multiple definition of `disp_write';
	CMakeFiles/amigahid-pico.dir/main.c.obj:(.bss.disp_write+0x0): first defined here
collect2: error: ld returned 1 exit status
