### PR TITLE
fix held ctrl-amiga-amiga

### DIFF
--- a/src/platform/amiga/keyboard_serial_io.c
+++ b/src/platform/amiga/keyboard_serial_io.c
@@ -164,7 +164,8 @@ void amiga_send(uint8_t keycode, bool up)
         amiga_release_reset();
     }
 
-    // copy input code, roll left, move msb to lsb
+    if (!in_reset) {
+	// copy input code, roll left, move msb to lsb
     sendcode = keycode | (up == true ? 0x80 : 0x00);
     sendcode <<= 1;
     if (up || (keycode & 0x80))
@@ -186,6 +187,7 @@ void amiga_send(uint8_t keycode, bool up)
         // shift the bit pattern for next iteration
         bit_mask >>= 1;
     }
+	}
 
     // set /dat to input for 5ms to signal end of key
     _keyboard_gpio_set(KBD_AMIGA_DAT, HIGH);
@@ -207,13 +209,13 @@ void amiga_assert_reset()
     // (thanks @reinauer for submitting this in issue #31 and testing on your a3000)
     _keyboard_gpio_set(KBD_AMIGA_CLK, LOW);
     sleep_us(500000);
-    _keyboard_gpio_set(KBD_AMIGA_CLK, HIGH);
 }
 
 void amiga_release_reset()
 {
     // ahprintf("[akb] *** RESET BEING RELEASED ***\n");
     _keyboard_gpio_set(KBD_AMIGA_RST, HIGH);
+    _keyboard_gpio_set(KBD_AMIGA_CLK, HIGH);
 }
 
 void amiga_service()


### PR DESCRIPTION
This PR fixes the behaviour of the adapter when it receives a long hold of CTRL LAMIGA RAMIGA.  Current state is that the machine will simply reset after 500ms, this PR ensures that the machines is held in reset until C-A-A is released.

This is important for amiga uses what are using wireless ROM switches which require a long hold of C-A-A to determine when to switch to a different ROM set.

[See documentation here](https://amigadev.elowar.com/read/ADCD_2.1/Hardware_Manual_guide/node0172.html)

Change summary:
* move CLK set high to amiga_release_reset
* disable key sending whilst in reset - which would change CLK state

Tested on an Amiga 2000 EATX with Boobip 27c400 Emulator ROMs.

Will probably need testing against an A500/A600/A1200 to ensure continued small box operation.