### PR TITLE
Fix AmigaHID-pico with GL.iNet Comet (GL-RM1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,18 @@ add_compile_options(-Wall -Werror)
 # uncomment for debug slurry
 add_compile_definitions(DEBUG_MESSAGES=1)
 
+# enable per-report mouse debug only when explicitly requested
+option(DEBUG_MOUSE "Enable per-report mouse debug output" OFF)
+if (DEBUG_MOUSE)
+	add_compile_definitions(DEBUG_MOUSE=1)
+endif ()
+
+# enable per-key keyboard debug only when explicitly requested
+option(DEBUG_KEYBOARD "Enable per-key keyboard debug output" OFF)
+if (DEBUG_KEYBOARD)
+	add_compile_definitions(DEBUG_KEYBOARD=1)
+endif ()
+
 # set the board revision (changes which pins are mapped to which ports)
 add_compile_definitions(${BOARD_TYPE})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,12 @@ if (DEBUG_KEYBOARD)
 	add_compile_definitions(DEBUG_KEYBOARD=1)
 endif ()
 
+# enable HID mount/status debug only when explicitly requested
+option(DEBUG_HID_STATUS "Enable HID status debug output" OFF)
+if (DEBUG_HID_STATUS)
+	add_compile_definitions(DEBUG_HID_STATUS=1)
+endif ()
+
 # set the board revision (changes which pins are mapped to which ports)
 add_compile_definitions(${BOARD_TYPE})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ pico_enable_stdio_uart(amigahid-pico 1)
 
 target_link_libraries(amigahid-pico PUBLIC
   pico_stdlib
+  pico_util
   pico_multicore
   hardware_dma
   hardware_gpio

--- a/src/platform/amiga/quad_mouse.c
+++ b/src/platform/amiga/quad_mouse.c
@@ -17,25 +17,32 @@
 
 #include "pico/stdlib.h"
 #include "pico/multicore.h"
+#include "pico/util/queue.h"
 #include "hardware/gpio.h"
 
-// mouse motion values, used between core0 and core1
-volatile int16_t x = 0, y = 0;
+#define AQM_MOTION_QUEUE_DEPTH 32
+
+typedef struct
+{
+    int16_t x;
+    int16_t y;
+} aqm_motion_t;
+
+static queue_t motion_queue;
 volatile uint8_t motion_divider = 2;
 
 enum _mouse_pin_state { LOW, HIGH };
 
-static inline int16_t _aqm_accumulate_motion(volatile int16_t *axis, int16_t delta)
+static inline int16_t _aqm_add_clamped(int16_t value, int16_t delta)
 {
-    int32_t sum = *axis + delta;
+    int32_t sum = value + delta;
 
     if (sum > INT16_MAX)
         sum = INT16_MAX;
     else if (sum < INT16_MIN)
         sum = INT16_MIN;
 
-    *axis = (int16_t)sum;
-    return *axis;
+    return (int16_t)sum;
 }
 
 static inline void _aqm_gpio_set(uint gpio, enum _mouse_pin_state state)
@@ -78,6 +85,8 @@ void amiga_quad_mouse_init()
     _aqm_gpio_set(QM1_AMIGA_B2, HIGH);
     _aqm_gpio_set(QM1_AMIGA_B3, HIGH);
 
+    queue_init(&motion_queue, sizeof(aqm_motion_t), AQM_MOTION_QUEUE_DEPTH);
+
     // start the mouse motion loop on core1
     multicore_launch_core1(amiga_quad_mouse_motion);
 }
@@ -101,15 +110,30 @@ void amiga_quad_mouse_button(enum amiga_quad_mouse_buttons button, bool pressed)
 
 void amiga_quad_mouse_set_motion(int16_t in_x, int16_t in_y)
 {
-    _aqm_accumulate_motion(&x, in_x);
-    _aqm_accumulate_motion(&y, in_y);
+    aqm_motion_t motion = { in_x, in_y };
+
+    if (!queue_try_add(&motion_queue, &motion)) {
+        aqm_motion_t merged;
+
+        // When the queue is full, coalesce with a queued sample rather than
+        // dropping motion outright.
+        if (queue_try_remove(&motion_queue, &merged)) {
+            merged.x = _aqm_add_clamped(merged.x, in_x);
+            merged.y = _aqm_add_clamped(merged.y, in_y);
+
+            if (queue_try_add(&motion_queue, &merged))
+                return;
+        }
+
+        queue_try_add(&motion_queue, &motion);
+    }
 }
 
 void amiga_quad_mouse_motion()
 {
     // ahprintf("[aqm] hello from core1, mouse motion output loop starting\n");
-    int16_t out_x, out_y;
-    int16_t in_x, in_y;
+    aqm_motion_t motion;
+    int16_t out_x = 0, out_y = 0;
     int16_t x_residue = 0, y_residue = 0;
     uint8_t quad_mx_state = 1, quad_my_state = 1;
     uint8_t divider;
@@ -127,68 +151,71 @@ void amiga_quad_mouse_motion()
      */
 
     while (1) {
-        // Batch new deltas so slow axis-only motion is not lost when we divide
-        // high-DPI mouse movement down to Amiga quadrature steps.
-        in_x = x;
-        in_y = y;
-        x = y = 0;
+        // Merge newly queued USB deltas between quadrature steps so we do not
+        // lose motion across cores or wait for an entire stale batch to drain.
         divider = motion_divider ? motion_divider : 1;
 
-        x_residue += in_x;
-        y_residue += in_y;
-        out_x = x_residue / divider;
-        out_y = y_residue / divider;
+        while (queue_try_remove(&motion_queue, &motion)) {
+            x_residue = _aqm_add_clamped(x_residue, motion.x);
+            y_residue = _aqm_add_clamped(y_residue, motion.y);
+        }
+
+        out_x = _aqm_add_clamped(out_x, x_residue / divider);
+        out_y = _aqm_add_clamped(out_y, y_residue / divider);
         x_residue %= divider;
         y_residue %= divider;
 
-        while ((out_x != 0) || (out_y != 0)) {
-            if (out_x != 0) {
-                // handle x-axis motion
-                if (out_x < 0)
-                    quad_mx_state--;
-                else if (out_x > 0)
-                    quad_mx_state++;
-                // fix wraparound
-                if (quad_mx_state == 255)
-                    quad_mx_state = 3;
-                else if (quad_mx_state == 4)
-                    quad_mx_state = 0;
-
-                switch (quad_mx_state) {
-                    case 0: _aqm_gpio_set(QM1_AMIGA_H, HIGH); break;
-                    case 1: _aqm_gpio_set(QM1_AMIGA_HQ, HIGH); break;
-                    case 2: _aqm_gpio_set(QM1_AMIGA_H, LOW); break;
-                    case 3: _aqm_gpio_set(QM1_AMIGA_HQ, LOW); break;
-                }
-            }
-
-            if (out_x < 0) out_x++;
-            if (out_x > 0) out_x--;
-
-            if (out_y != 0) {
-                // handle y-axis motion
-                if (out_y < 0)
-                    quad_my_state--;
-                else if (out_y > 0)
-                    quad_my_state++;
-                // fix wraparound
-                if (quad_my_state == 255)
-                    quad_my_state = 3;
-                else if (quad_my_state == 4)
-                    quad_my_state = 0;
-
-                switch (quad_my_state) {
-                    case 0: _aqm_gpio_set(QM1_AMIGA_V, HIGH); break;
-                    case 1: _aqm_gpio_set(QM1_AMIGA_VQ, HIGH); break;
-                    case 2: _aqm_gpio_set(QM1_AMIGA_V, LOW); break;
-                    case 3: _aqm_gpio_set(QM1_AMIGA_VQ, LOW); break;
-                }
-            }
-
-            if (out_y < 0) out_y++;
-            if (out_y > 0) out_y--;
-
-            sleep_us(300); // delay before next iteration to prevent missing state change
+        if ((out_x == 0) && (out_y == 0)) {
+            tight_loop_contents();
+            continue;
         }
+
+        if (out_x != 0) {
+            // handle x-axis motion
+            if (out_x < 0)
+                quad_mx_state--;
+            else if (out_x > 0)
+                quad_mx_state++;
+            // fix wraparound
+            if (quad_mx_state == 255)
+                quad_mx_state = 3;
+            else if (quad_mx_state == 4)
+                quad_mx_state = 0;
+
+            switch (quad_mx_state) {
+                case 0: _aqm_gpio_set(QM1_AMIGA_H, HIGH); break;
+                case 1: _aqm_gpio_set(QM1_AMIGA_HQ, HIGH); break;
+                case 2: _aqm_gpio_set(QM1_AMIGA_H, LOW); break;
+                case 3: _aqm_gpio_set(QM1_AMIGA_HQ, LOW); break;
+            }
+        }
+
+        if (out_x < 0) out_x++;
+        if (out_x > 0) out_x--;
+
+        if (out_y != 0) {
+            // handle y-axis motion
+            if (out_y < 0)
+                quad_my_state--;
+            else if (out_y > 0)
+                quad_my_state++;
+            // fix wraparound
+            if (quad_my_state == 255)
+                quad_my_state = 3;
+            else if (quad_my_state == 4)
+                quad_my_state = 0;
+
+            switch (quad_my_state) {
+                case 0: _aqm_gpio_set(QM1_AMIGA_V, HIGH); break;
+                case 1: _aqm_gpio_set(QM1_AMIGA_VQ, HIGH); break;
+                case 2: _aqm_gpio_set(QM1_AMIGA_V, LOW); break;
+                case 3: _aqm_gpio_set(QM1_AMIGA_VQ, LOW); break;
+            }
+        }
+
+        if (out_y < 0) out_y++;
+        if (out_y > 0) out_y--;
+
+        sleep_us(300); // delay before next iteration to prevent missing state change
     }
 }

--- a/src/platform/amiga/quad_mouse.c
+++ b/src/platform/amiga/quad_mouse.c
@@ -20,11 +20,23 @@
 #include "hardware/gpio.h"
 
 // mouse motion values, used between core0 and core1
-volatile int8_t x = 0, y = 0;
-volatile bool motion_flag = false;
+volatile int16_t x = 0, y = 0;
 volatile uint8_t motion_divider = 2;
 
 enum _mouse_pin_state { LOW, HIGH };
+
+static inline int16_t _aqm_accumulate_motion(volatile int16_t *axis, int16_t delta)
+{
+    int32_t sum = *axis + delta;
+
+    if (sum > INT16_MAX)
+        sum = INT16_MAX;
+    else if (sum < INT16_MIN)
+        sum = INT16_MIN;
+
+    *axis = (int16_t)sum;
+    return *axis;
+}
 
 static inline void _aqm_gpio_set(uint gpio, enum _mouse_pin_state state)
 {
@@ -87,21 +99,20 @@ void amiga_quad_mouse_button(enum amiga_quad_mouse_buttons button, bool pressed)
     }
 }
 
-void amiga_quad_mouse_set_motion(int8_t in_x, int8_t in_y)
+void amiga_quad_mouse_set_motion(int16_t in_x, int16_t in_y)
 {
-    x = in_x;
-    y = in_y;
-    motion_flag = true;
-
-    // @todo use fifo write here to unblock core1 thread?
+    _aqm_accumulate_motion(&x, in_x);
+    _aqm_accumulate_motion(&y, in_y);
 }
 
 void amiga_quad_mouse_motion()
 {
     // ahprintf("[aqm] hello from core1, mouse motion output loop starting\n");
-    int8_t out_x, out_y;
-    uint8_t quad_mx_state = 0, quad_my_state = 0;
-    bool motion_x_skip = false, motion_y_skip = false;
+    int16_t out_x, out_y;
+    int16_t in_x, in_y;
+    int16_t x_residue = 0, y_residue = 0;
+    uint8_t quad_mx_state = 1, quad_my_state = 1;
+    uint8_t divider;
 
     /**
      * a little note about quadrature motion state.
@@ -116,22 +127,22 @@ void amiga_quad_mouse_motion()
      */
 
     while (1) {
-        // @todo use blocking fifo read here to prevent wasting cycles?
-        out_x = x;
-        out_y = y;
+        // Batch new deltas so slow axis-only motion is not lost when we divide
+        // high-DPI mouse movement down to Amiga quadrature steps.
+        in_x = x;
+        in_y = y;
         x = y = 0;
-        motion_flag = false;
+        divider = motion_divider ? motion_divider : 1;
 
-        while (((out_x != 0) || (out_y != 0)) && !motion_flag) {
-            motion_x_skip = false;
-            motion_y_skip = false;
+        x_residue += in_x;
+        y_residue += in_y;
+        out_x = x_residue / divider;
+        out_y = y_residue / divider;
+        x_residue %= divider;
+        y_residue %= divider;
 
-            if ((out_x % motion_divider) != 0)
-                motion_x_skip = true;
-            if ((out_y % motion_divider) != 0)
-                motion_y_skip = true;
-
-            if ((out_x != 0) && !motion_x_skip) {
+        while ((out_x != 0) || (out_y != 0)) {
+            if (out_x != 0) {
                 // handle x-axis motion
                 if (out_x < 0)
                     quad_mx_state--;
@@ -154,7 +165,7 @@ void amiga_quad_mouse_motion()
             if (out_x < 0) out_x++;
             if (out_x > 0) out_x--;
 
-            if ((out_y != 0) && !motion_y_skip) {
+            if (out_y != 0) {
                 // handle y-axis motion
                 if (out_y < 0)
                     quad_my_state--;
@@ -176,9 +187,6 @@ void amiga_quad_mouse_motion()
 
             if (out_y < 0) out_y++;
             if (out_y > 0) out_y--;
-
-            //if (motion_x_skip && motion_y_skip)
-            //    continue;
 
             sleep_us(300); // delay before next iteration to prevent missing state change
         }

--- a/src/platform/amiga/quad_mouse.h
+++ b/src/platform/amiga/quad_mouse.h
@@ -19,6 +19,6 @@ enum amiga_quad_mouse_buttons { AQM_LEFT, AQM_MIDDLE, AQM_RIGHT };
 void amiga_quad_mouse_init();
 void amiga_quad_mouse_motion();
 void amiga_quad_mouse_button(enum amiga_quad_mouse_buttons button, bool pressed);
-void amiga_quad_mouse_set_motion(int8_t in_x, int8_t in_y);
+void amiga_quad_mouse_set_motion(int16_t in_x, int16_t in_y);
 
 #endif

--- a/src/usb_hid.c
+++ b/src/usb_hid.c
@@ -79,7 +79,9 @@ void hid_app_task(void)
 void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const *desc_report, uint16_t desc_len)
 {
     uint8_t hid_protocol = tuh_hid_interface_protocol(dev_addr, instance);
+    bool receive_ok;
 
+    hid_info[instance].report_count = 0;
     dbgcons_plug(hid_protocol_type[hid_protocol]);
 
     // this part doesn't entirely make sense to me; hid devices come in two modes, boot protocol and report;
@@ -91,7 +93,10 @@ void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const *desc_re
         // ahprintf("[PLUG] %02x report(s)\n", hid_info[instance].report_count);
     }
 
-    if (!tuh_hid_receive_report(dev_addr, instance)) {
+    receive_ok = tuh_hid_receive_report(dev_addr, instance);
+    dbgcons_hid_status(dev_addr, instance, hid_protocol, receive_ok, hid_info[instance].report_count, true);
+
+    if (!receive_ok) {
         // ahprintf("[PLUG] warning! report request failed; delayed initialisation?\n");
     }
 }
@@ -107,6 +112,8 @@ void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance)
     uint8_t hid_protocol = tuh_hid_interface_protocol(dev_addr, instance);
 
     dbgcons_unplug(hid_protocol_type[hid_protocol]);
+    dbgcons_hid_status(dev_addr, instance, hid_protocol, true, hid_info[instance].report_count, false);
+    hid_info[instance].report_count = 0;
 }
 
 /**
@@ -253,6 +260,7 @@ static void handle_event_mouse(uint8_t dev_addr, uint8_t instance, hid_mouse_rep
 
     // this would spam horrendously, so even when debug messages are on, this is probably... too much.
     // ahprintf("[hid] x: %d y: %d\n", report->x, report->y);
+    dbgcons_mouse_report(report->x, report->y, report->buttons);
 
     if (report->x || report->y)
         amiga_quad_mouse_set_motion(report->x, report->y);

--- a/src/util/debug_cons.c
+++ b/src/util/debug_cons.c
@@ -34,7 +34,9 @@ void dbgcons_init()
     debug_counters.unplug_events = 0;
 
     dbgcons_print_counters();
+#ifdef DEBUG_HID_STATUS
     disp_write(0, 2, "hid --");
+#endif
 #ifdef DEBUG_MOUSE
     disp_write(0, 3, "mouse --");
 #endif
@@ -139,6 +141,7 @@ void dbgcons_amiga_mod(uint8_t outcode, char updown)
 
 void dbgcons_hid_status(uint8_t dev_addr, uint8_t instance, uint8_t hid_protocol, bool receive_ok, uint8_t report_count, bool mounted)
 {
+#ifdef DEBUG_HID_STATUS
     char linebuf[32] = "";
 
     snprintf(
@@ -173,6 +176,14 @@ void dbgcons_hid_status(uint8_t dev_addr, uint8_t instance, uint8_t hid_protocol
         receive_ok ? "ok" : "fail"
     );
     disp_write(17, 2, linebuf);
+#else
+    (void)dev_addr;
+    (void)instance;
+    (void)hid_protocol;
+    (void)receive_ok;
+    (void)report_count;
+    (void)mounted;
+#endif
 }
 
 void dbgcons_mouse_report(int16_t x, int16_t y, uint8_t buttons)

--- a/src/util/debug_cons.c
+++ b/src/util/debug_cons.c
@@ -35,7 +35,9 @@ void dbgcons_init()
 
     dbgcons_print_counters();
     disp_write(0, 2, "hid --");
+#ifdef DEBUG_MOUSE
     disp_write(0, 3, "mouse --");
+#endif
 }
 
 void dbgcons_print_counters()
@@ -106,6 +108,7 @@ void dbgcons_unplug(enum debug_plug_types devtype)
 
 void dbgcons_amiga_key(uint8_t incode, uint8_t outcode, char *updown)
 {
+#ifdef DEBUG_KEYBOARD
     char linebuf[32] = "";
 
     ahprintf(
@@ -122,6 +125,11 @@ void dbgcons_amiga_key(uint8_t incode, uint8_t outcode, char *updown)
     );
 
     disp_write(0, 1, linebuf);
+#else
+    (void)incode;
+    (void)outcode;
+    (void)updown;
+#endif
 }
 
 void dbgcons_amiga_mod(uint8_t outcode, char updown)
@@ -169,6 +177,7 @@ void dbgcons_hid_status(uint8_t dev_addr, uint8_t instance, uint8_t hid_protocol
 
 void dbgcons_mouse_report(int16_t x, int16_t y, uint8_t buttons)
 {
+#ifdef DEBUG_MOUSE
     char linebuf[32] = "";
 
     snprintf(
@@ -190,4 +199,9 @@ void dbgcons_mouse_report(int16_t x, int16_t y, uint8_t buttons)
     );
 
     disp_write(0, 3, linebuf);
+#else
+    (void)x;
+    (void)y;
+    (void)buttons;
+#endif
 }

--- a/src/util/debug_cons.c
+++ b/src/util/debug_cons.c
@@ -34,6 +34,8 @@ void dbgcons_init()
     debug_counters.unplug_events = 0;
 
     dbgcons_print_counters();
+    disp_write(0, 2, "hid --");
+    disp_write(0, 3, "mouse --");
 }
 
 void dbgcons_print_counters()
@@ -125,4 +127,67 @@ void dbgcons_amiga_key(uint8_t incode, uint8_t outcode, char *updown)
 void dbgcons_amiga_mod(uint8_t outcode, char updown)
 {
     // ls rs cl ct la ra lam ram
+}
+
+void dbgcons_hid_status(uint8_t dev_addr, uint8_t instance, uint8_t hid_protocol, bool receive_ok, uint8_t report_count, bool mounted)
+{
+    char linebuf[32] = "";
+
+    snprintf(
+        linebuf,
+        sizeof(linebuf),
+        "hid %c a%02x i%02x p%02x r%u",
+        mounted ? '+' : '-',
+        dev_addr,
+        instance,
+        hid_protocol,
+        report_count
+    );
+
+    ahprintf(
+        VT_CUP_POS VT_EL_LIN
+        "[hid] %s addr:%02x inst:%02x proto:%02x reports:%u rx:%s\n",
+        5, 1,
+        mounted ? "mount" : "umount",
+        dev_addr,
+        instance,
+        hid_protocol,
+        report_count,
+        receive_ok ? "ok" : "fail"
+    );
+
+    disp_write(0, 2, linebuf);
+
+    snprintf(
+        linebuf,
+        sizeof(linebuf),
+        "rx %s",
+        receive_ok ? "ok" : "fail"
+    );
+    disp_write(17, 2, linebuf);
+}
+
+void dbgcons_mouse_report(int16_t x, int16_t y, uint8_t buttons)
+{
+    char linebuf[32] = "";
+
+    snprintf(
+        linebuf,
+        sizeof(linebuf),
+        "m x%+04d y%+04d b%02x",
+        x,
+        y,
+        buttons
+    );
+
+    ahprintf(
+        VT_CUP_POS VT_EL_LIN
+        "[mouse] x:%d y:%d buttons:%02x\n",
+        6, 1,
+        x,
+        y,
+        buttons
+    );
+
+    disp_write(0, 3, linebuf);
 }

--- a/src/util/debug_cons.h
+++ b/src/util/debug_cons.h
@@ -11,6 +11,7 @@
 #ifndef _PLATFORM_COMMON_DEBUG_CONS_H
 #define _PLATFORM_COMMON_DEBUG_CONS_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 enum debug_plug_types { AP_H_UNKNOWN, AP_H_KEYBOARD, AP_H_MOUSE, AP_H_CONTROLLER };
@@ -36,5 +37,9 @@ void dbgcons_plug(enum debug_plug_types devtype);
 void dbgcons_unplug(enum debug_plug_types devtype);
 
 void dbgcons_amiga_key(uint8_t incode, uint8_t outcode, char *updown);
+
+void dbgcons_hid_status(uint8_t dev_addr, uint8_t instance, uint8_t hid_protocol, bool receive_ok, uint8_t report_count, bool mounted);
+
+void dbgcons_mouse_report(int16_t x, int16_t y, uint8_t buttons);
 
 #endif // _PLATFORM_COMMON_DEBUG_CONS_H


### PR DESCRIPTION
Fix small/axis-only mouse movements and input latency observed with a GL.iNet Comet (GL-RM1).

The changes preserve fractional deltas, synchronize motion across cores, fix quadrature transitions at negative starts and direction changes, and make per-event mouse/keyboard and HID-status diagnostics opt-in.

The motion loop sums queued deltas before each output step. Opposite input cancels pending motion; a sufficiently large backlog can still delay reversal.

OLED transfers use DMA. The disabled diagnostic paths also perform synchronous text rendering, full-frame copying/queueing, and UART output; their individual timing costs have not been isolated.

Validated with local host regressions and sanitizer checks, plus rev2/rev4 Release and Debug firmware builds (all diagnostic flags enabled in Debug). Physical non-KVM mouse QA remains unverified.